### PR TITLE
Correction of Qiita reference article URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Zoom Meeting Plus
-You can join the zoom meeting with avatar as you like. 
+You can join the zoom meeting with avatar as you like.
 
 # Documentation
-Documentation is published as blog. Please see them. 
+Documentation is published as blog. Please see them.
 ## English
 1. [Time keeper bot with Zoom Meeting SDK](https://dannadori.medium.com/time-keeper-bot-with-zoom-meeting-sdk-11f2feb3dc14)
 1. [Talking avatar with Zoom Meeting SDK](https://dannadori.medium.com/talking-avatar-with-zoom-meeting-sdk-c67444aa9ea1)
@@ -12,7 +12,7 @@ Documentation is published as blog. Please see them.
 
 ## Japanese
 1. [Zoom Meeting SDKでタイムキーパーちゃんを作る。](https://qiita.com/wok/items/205c086f19a7ff73718d)
-1. [Zoom Meeting SDKでアバターにいろいろしゃべらせる。](https://qiita.com/wok/items/205c086f19a7ff73718d)
+1. [Zoom Meeting SDKでアバターにいろいろしゃべらせる。](https://qiita.com/wok/items/0450c8620f11a371bd8b)
 1. [Zoom Meeting SDKをつかって会議にアバターで参加する](https://qiita.com/wok/items/1bccd567e844ac4e8979)
 1. [Zoom Meeting SDKでなんちゃってボイスチェンジャー](https://qiita.com/wok/items/08c9505d5c3c95d8956d)
 1. [Zoom Meetingにアバターで参加するぞ。番外編](https://qiita.com/wok/items/4f51e1a72d735b75f73f)


### PR DESCRIPTION
The URL link to the article below was incorrect and has been corrected.
```
Zoom Meeting SDKでアバターにいろいろしゃべらせる。
```